### PR TITLE
Fix createMessage to not require time and make layout required for Notification

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -22,7 +22,7 @@ module.exports = function (opts) {
       opts.layout instanceof Layout ? opts.layout : new Layout(opts.layout);
   }
 
-  if (!this.time) {
-    throw new Error('`time` is required by Notification.');
+  if (!this.layout) {
+    throw new Error('`layout` is required by Notification.');
   }
 };

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -43,6 +43,9 @@ var Pin = module.exports = function (opts) {
   }
 
   if (opts && opts.updateMessage) {
+    if (!opts.updateMessage.time) {
+      throw new Error('`time` is required by updateMessage.');
+    }
     this.updateMessage = opts.updateMessage instanceof Notification ?
       opts.updateMessage : new Notification(opts.updateMessage);
   }

--- a/test/notification.js
+++ b/test/notification.js
@@ -35,9 +35,8 @@ describe('Notification', function () {
     done();
   });
 
-  it('should throw an error if time is not set', function (done) {
-    var notificationData = { layout: fakeLayout };
-    assert.throws(function () { new Notification(notificationData); });
+  it('should throw an error if layout is not set', function (done) {
+    assert.throws(function () { new Notification(); });
     done();
   });
 

--- a/test/pin.js
+++ b/test/pin.js
@@ -61,6 +61,22 @@ describe('Pin', function () {
     done();
   });
 
+  it('should throw if updateMessage time is not set', function (done) {
+    var pinData = {
+      time: new Date(),
+      layout: layout,
+      updateMessage: new Pin.Notification({
+        layout: {
+          type: 'genericReminder',
+          title: 'Title',
+          tinyIcon: Pin.Icon.BULB
+        }
+      })
+    };
+    assert.throws(function () { new Pin(pinData); });
+    done();
+  });
+
   it('should set the properties passed in at construction', function (done) {
     var now = new Date();
     var pin  = new Pin({
@@ -72,8 +88,21 @@ describe('Pin', function () {
         title: 'Title',
         tinyIcon: Pin.Icon.PIN
       }),
-      createMessage: new Pin.Notification({ time: new Date() }),
-      updateMessage: new Pin.Notification({ time: new Date() }),
+      createMessage: new Pin.Notification({
+        layout: {
+          type: 'genericReminder',
+          title: 'Title',
+          tinyIcon: Pin.Icon.CALENDAR
+        }
+      }),
+      updateMessage: new Pin.Notification({
+        time: new Date(),
+        layout: {
+          type: 'genericReminder',
+          title: 'Title',
+          tinyIcon: Pin.Icon.BULB
+        }
+      }),
       actions: [
         new Pin.Action({ type: Pin.ActionType.OPEN_WATCH_APP })
       ],
@@ -116,7 +145,11 @@ describe('Pin', function () {
         tinyIcon: Pin.Icon.FOOTBALL
       }),
       createMessage: {
-        time: new Date()
+        layout: {
+          type: 'genericReminder',
+          title: 'Title',
+          tinyIcon: Pin.Icon.PIN
+        }
       },
     });
     assert.ok(pin.createMessage instanceof Pin.Notification);
@@ -132,7 +165,12 @@ describe('Pin', function () {
         tinyIcon: Pin.Icon.SUN
       }),
       updateMessage: {
-        time: new Date()
+        time: new Date(),
+        layout: {
+          type: 'genericReminder',
+          title: 'Title',
+          tinyIcon: Pin.Icon.ALARM
+        }
       },
     });
     assert.ok(pin.updateMessage instanceof Pin.Notification);


### PR DESCRIPTION
`Notification` was requiring `time` but `createMessage` does not take `time`. Since `updateMessage` requires `time`, this fix checks for `updateMessage.time` in the `Pin` constructor instead.