### PR TITLE
Add primaryColor and secondaryColor layout attributes.

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -71,6 +71,20 @@ module.exports = function (opts) {
     this.foregroundColor = opts.foregroundColor;
   }
 
+  if (opts && opts.primaryColor) {
+    if (typeof opts.primaryColor !== 'string') {
+      throw new Error('Expected primaryColor to be a string.');
+    }
+    this.primaryColor = opts.primaryColor;
+  }
+
+  if (opts && opts.secondaryColor) {
+    if (typeof opts.secondaryColor !== 'string') {
+      throw new Error('Expected secondaryColor to be a string.');
+    }
+    this.secondaryColor = opts.secondaryColor;
+  }
+
   if (opts && opts.backgroundColor) {
     if (typeof opts.backgroundColor !== 'string') {
       throw new Error('Expected backgroundColor to be a string.');

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "homepage": "https://github.com/pebble/pebble-api-node",
   "dependencies": {
-    "request": "^2.53.0"
+    "request": "^2.55.0"
   },
   "license": "MIT",
   "devDependencies": {
-    "istanbul": "^0.3.8",
-    "jscs": "^1.11.3",
-    "jshint": "^2.6.3",
-    "mocha": "^2.2.1",
-    "nock": "^1.2.0"
+    "istanbul": "^0.3.14",
+    "jscs": "^1.13.1",
+    "jshint": "^2.7.0",
+    "mocha": "^2.2.5",
+    "nock": "^1.9.0"
   }
 }

--- a/test/layout.js
+++ b/test/layout.js
@@ -109,6 +109,24 @@ describe('Layout', function () {
     done();
   });
 
+  it('should throw if primaryColor is not a string', function (done) {
+    var layoutData = {
+      type: Pin.LayoutType.GENERIC_PIN,
+      primaryColor: 5
+    };
+    assert.throws(function () { new Layout(layoutData); });
+    done();
+  });
+
+  it('should throw if secondaryColor is not a string', function (done) {
+    var layoutData = {
+      type: Pin.LayoutType.GENERIC_PIN,
+      secondaryColor: 5
+    };
+    assert.throws(function () { new Layout(layoutData); });
+    done();
+  });
+
   it('should throw if backgroundColor is not a string', function (done) {
     var layoutData = {
       type: Pin.LayoutType.GENERIC_PIN,
@@ -330,7 +348,8 @@ describe('Layout', function () {
         title: 'Pin Title',
         tinyIcon: Pin.Icon.NOTIFICATION_FLAG,
         backgroundColor: '#222222',
-        foregroundColor: '#445566'
+        foregroundColor: '#445566',
+        secondaryColor: '#000000',
       };
       new Layout(layoutData);
       done();
@@ -354,8 +373,9 @@ describe('Layout', function () {
         title: 'Pin Title',
         headings: ['heading1', 'heading2'],
         paragraphs: ['paragraph1', 'paragraph2'],
-        foregroundColor: '#445566',
-        backgroundColor: '#222222'
+        backgroundColor: '#222222',
+        primaryColor: '#445566',
+        secondaryColor: '#000000',
       };
       new Layout(layoutData);
       done();

--- a/test/timeline.js
+++ b/test/timeline.js
@@ -459,4 +459,24 @@ describe('Timeline', function () {
 
   });
 
+  describe('#request', function () {
+
+    it('should handle no headers', function (done) {
+      var timelineApi = nock('http://timeline_api')
+                        .get('/v1/some/endpoint').reply(200, []);
+
+      var opts = {
+        method: 'GET',
+        endpoint: '/v1/some/endpoint'
+      };
+
+      timeline._request(opts, function (err) {
+        assert.equal(err, null);
+        timelineApi.done();
+        done();
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
I've left `foregroundColor` as is so we don't break backwards compatibility. The mobile apps acknowledge `foregroundColor` as an alias for `primaryColor`.
